### PR TITLE
Correcting some wrong references to dependency versions using fixed vers...

### DIFF
--- a/src/main/resources/archetype-resources/admin/pom.xml
+++ b/src/main/resources/archetype-resources/admin/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>${groupId}</groupId>
 			<artifactId>core</artifactId>
-			<version>1.0</version>
+			<version>${version}</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/src/main/resources/archetype-resources/ear/src/main/application/META-INF/maven-application.xml
+++ b/src/main/resources/archetype-resources/ear/src/main/application/META-INF/maven-application.xml
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-<?xml version="${version}" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd" version="5">
   <display-name>${artifactId}</display-name>
   <module>

--- a/src/main/resources/archetype-resources/frontend/pom.xml
+++ b/src/main/resources/archetype-resources/frontend/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>${groupId}</groupId>
             <artifactId>core</artifactId>
-            <version>1.0</version>
+            <version>${version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
...ion number. And there was a wrong  tag on xml version tag.

When using a version parameter diferent from 1.0, the build fails because admin/pom.xml and frontend/pom.xml reference to core was using fixed 1.0 instead the ${version} snippet.
